### PR TITLE
Fix des crochets

### DIFF
--- a/assets/minecraft/optifine/cit/general/outils/crochet/crochet.properties
+++ b/assets/minecraft/optifine/cit/general/outils/crochet/crochet.properties
@@ -2,6 +2,3 @@ type=item
 matchItems=tripwire_hook
 texture=crochet
 nbt.display.Name=iregex:Crochets.*
-
-#Enchantement 35 : fortune
-enchantment=minecraft:fortune


### PR DESCRIPTION
L'objet crochet est déjà enchanté en jeu après le craft et la propriété ne servait à rien. Elle était tolérée et intutilisée par optifine, et était refusée par le mod CIT resewn. Fonctionne à 100% en jeu que ce soit avec optifine ou le pack fabulously optimized