### PR TITLE
Fixpaths

### DIFF
--- a/assets/minecraft/optifine/cit/general/combat/armes/cac/hampe_arret/hampe_arret.properties
+++ b/assets/minecraft/optifine/cit/general/combat/armes/cac/hampe_arret/hampe_arret.properties
@@ -1,5 +1,5 @@
 type=item
 matchItems=iron_axe
-model=~/cit/guildes/garde/armes/armes_liees/arme_hast
+model=assets/minecraft/optifine/cit/guildes/garde/armes/armes_liees/arme_hast
 texture=hampe_arret
-nbt.display.Name=iregex:(?!.*Acier.*).*Hampe.*(arret|arrêt).*
+nbt.display.Name=iregex:(?!.*Acier.*).*Hampe.*(arret|arr\u00EAt).*

--- a/assets/minecraft/optifine/cit/general/combat/armes/cac/hampe_arret/hampe_arret_acier.properties
+++ b/assets/minecraft/optifine/cit/general/combat/armes/cac/hampe_arret/hampe_arret_acier.properties
@@ -1,5 +1,5 @@
 type=item
 matchItems=iron_axe
-model=~/cit/guildes/garde/armes/armes_liees/arme_hast
+model=assets/minecraft/optifine/cit/guildes/garde/armes/armes_liees/arme_hast
 texture=hampe_arret_acier
-nbt.display.Name=iregex:.*Hampe.*(arret|arrêt).*acier.*
+nbt.display.Name=iregex:.*Hampe.*(arret|arr\u00EAt).*acier.*

--- a/assets/minecraft/optifine/cit/general/combat/armes/cac/hampe_arret/hampe_arret_diamant.properties
+++ b/assets/minecraft/optifine/cit/general/combat/armes/cac/hampe_arret/hampe_arret_diamant.properties
@@ -1,5 +1,5 @@
 type=item
 matchItems=diamond_axe
-model=~/cit/guildes/garde/armes/armes_liees/arme_hast
+model=assets/minecraft/optifine/cit/guildes/garde/armes/armes_liees/arme_hast
 texture=hampe_arret_diamant
-nbt.display.Name=iregex:.*Hampe.*(arret|arrêt).*
+nbt.display.Name=iregex:.*Hampe.*(arret|arr\u00EAt).*

--- a/assets/minecraft/optifine/cit/general/combat/armes/cac/sabres/katanas/katana_acier/katana_acier.properties
+++ b/assets/minecraft/optifine/cit/general/combat/armes/cac/sabres/katanas/katana_acier/katana_acier.properties
@@ -1,5 +1,5 @@
 type=item
 matchItems=iron_sword
-model=~/cit/source_models/katana
+model=assets/minecraft/optifine/cit/source_models/katana.json
 texture=katana_acier
 nbt.display.Name=iregex:(?=.*acier.*)(.*Katana.*)

--- a/assets/minecraft/optifine/cit/general/combat/armes/cac/sabres/katanas/katana_adamantin/katana_adamantin.properties
+++ b/assets/minecraft/optifine/cit/general/combat/armes/cac/sabres/katanas/katana_adamantin/katana_adamantin.properties
@@ -1,5 +1,5 @@
 type=item
 matchItems=diamond_sword
-model=~/cit/source_models/katana
+model=assets/minecraft/optifine/cit/source_models/katana.json
 texture=katana_adamantin
 nbt.display.Name=iregex:.*Katana.*

--- a/assets/minecraft/optifine/cit/general/combat/armes/cac/sabres/katanas/katana_fer/katana_fer.properties
+++ b/assets/minecraft/optifine/cit/general/combat/armes/cac/sabres/katanas/katana_fer/katana_fer.properties
@@ -1,5 +1,5 @@
 type=item
 matchItems=iron_sword
-model=~/cit/source_models/katana
+model=assets/minecraft/optifine/cit/source_models/katana.json
 texture=katana_fer
 nbt.display.Name=iregex:(?!Acier|acier)(.*Katana.*)

--- a/assets/minecraft/optifine/cit/general/combat/armes/cac/sabres/messers/messer_1m_acier/messer_acier.properties
+++ b/assets/minecraft/optifine/cit/general/combat/armes/cac/sabres/messers/messer_1m_acier/messer_acier.properties
@@ -1,5 +1,5 @@
 type=item
 matchItems=iron_sword
 texture=messer_acier
-model=~/cit/source_models/messer
+model=assets/minecraft/optifine/cit/source_models/messer.json
 nbt.display.Name=iregex:(?=.*acier.*)(?!.*Grand.*)(.*Messer.*)

--- a/assets/minecraft/optifine/cit/general/combat/armes/cac/sabres/messers/messer_1m_adamatin/messer_adamantin.properties
+++ b/assets/minecraft/optifine/cit/general/combat/armes/cac/sabres/messers/messer_1m_adamatin/messer_adamantin.properties
@@ -1,5 +1,5 @@
 type=item
 matchItems=diamond_sword
 texture=messer_adamantin
-model=~/cit/source_models/messer
+model=assets/minecraft/optifine/cit/source_models/messer.json
 nbt.display.Name=iregex:(?!.*Grand.*)(.*Messer.*)

--- a/assets/minecraft/optifine/cit/general/combat/armes/cac/sabres/messers/messer_1m_fer/messer.properties
+++ b/assets/minecraft/optifine/cit/general/combat/armes/cac/sabres/messers/messer_1m_fer/messer.properties
@@ -1,5 +1,5 @@
 type=item
 matchItems=iron_sword
 texture=messer
-model=~/cit/source_models/messer
+model=assets/minecraft/optifine/cit/source_models/messer.json
 nbt.display.Name=iregex:(?!Acier|acier)(?!.*Grand.*)(.*Messer.*)

--- a/assets/minecraft/optifine/cit/general/combat/armes/cac/sabres/messers/messer_2m_acier/messer_2m_acier.properties
+++ b/assets/minecraft/optifine/cit/general/combat/armes/cac/sabres/messers/messer_2m_acier/messer_2m_acier.properties
@@ -1,5 +1,5 @@
 type=item
 matchItems=iron_sword
 texture=messer_2m_acier
-model=~/cit/source_models/messer
+model=assets/minecraft/optifine/cit/source_models/messer.json
 nbt.display.Name=iregex:(?=.*acier.*)(.*Grand.*)(.*Messer.*)

--- a/assets/minecraft/optifine/cit/general/combat/armes/cac/sabres/messers/messer_2m_adamantin/messer_2m_adamantin.properties
+++ b/assets/minecraft/optifine/cit/general/combat/armes/cac/sabres/messers/messer_2m_adamantin/messer_2m_adamantin.properties
@@ -1,5 +1,5 @@
 type=item
 matchItems=diamond_sword
 texture=messer_2m_adamantin
-model=~/cit/source_models/messer
+model=assets/minecraft/optifine/cit/source_models/messer.json
 nbt.display.Name=iregex:(.*Grand.*)(.*Messer.*)

--- a/assets/minecraft/optifine/cit/general/combat/armes/cac/sabres/messers/messer_2m_fer/messer_2m.properties
+++ b/assets/minecraft/optifine/cit/general/combat/armes/cac/sabres/messers/messer_2m_fer/messer_2m.properties
@@ -1,5 +1,5 @@
 type=item
 matchItems=iron_sword
 texture=messer_2m
-model=~/cit/source_models/messer
+model=assets/minecraft/optifine/cit/source_models/messer.json
 nbt.display.Name=iregex:(?!Acier|acier)(.*Grand.*)(.*Messer.*)

--- a/assets/minecraft/optifine/cit/guildes/division_cristaline/armes_cristallines/cac/sabres/katana/katana_cristal.properties
+++ b/assets/minecraft/optifine/cit/guildes/division_cristaline/armes_cristallines/cac/sabres/katana/katana_cristal.properties
@@ -1,5 +1,5 @@
 type=item
 matchItems=iron_sword
-model=~/cit/source_models/katana
+model=assets/minecraft/optifine/cit/source_models/katana.json
 texture=katana_cristal
 nbt.division=katana_cristal

--- a/assets/minecraft/optifine/cit/guildes/division_cristaline/armes_cristallines/cac/sabres/messers/messer_1m/messer_cristal.properties
+++ b/assets/minecraft/optifine/cit/guildes/division_cristaline/armes_cristallines/cac/sabres/messers/messer_1m/messer_cristal.properties
@@ -1,5 +1,5 @@
 type=item
 matchItems=iron_sword
 texture=messer_cristal
-model=~/cit/source_models/messer
+model=assets/minecraft/optifine/cit/source_models/messer.json
 nbt.division=messer_une_main_cristal

--- a/assets/minecraft/optifine/cit/guildes/division_cristaline/armes_cristallines/cac/sabres/messers/messer_2m/messer_2m_cristal.properties
+++ b/assets/minecraft/optifine/cit/guildes/division_cristaline/armes_cristallines/cac/sabres/messers/messer_2m/messer_2m_cristal.properties
@@ -1,5 +1,5 @@
 type=item
 matchItems=iron_sword
 texture=messer_2m_cristal
-model=~/cit/source_models/messer
+model=assets/minecraft/optifine/cit/source_models/messer.json
 nbt.division=messer_deux_mains_cristal

--- a/assets/minecraft/optifine/cit/guildes/division_cristaline/armes_cristallines/cac/sabres/nodachi/nodachi_cristal.properties
+++ b/assets/minecraft/optifine/cit/guildes/division_cristaline/armes_cristallines/cac/sabres/nodachi/nodachi_cristal.properties
@@ -1,5 +1,5 @@
 type=item
 matchItems=iron_axe
-model=optifine/cit/source_models/2xhand_espadons
+model=assets/minecraft/optifine/cit/source_models/2xhand_espadons.json
 texture=nodachi_cristal
 nbt.division=nodachi_cristal

--- a/assets/minecraft/optifine/cit/guildes/garde/armes/armes_liees/lellion/epee_batarde_lellion.properties
+++ b/assets/minecraft/optifine/cit/guildes/garde/armes/armes_liees/lellion/epee_batarde_lellion.properties
@@ -1,6 +1,6 @@
 type=item
 matchItems=diamond_sword
 hand=main
-model=~/cit/general/combat/armes/cac/epee_batarde/epee_batarde
+model=assets/minecraft/optifine/cit/general/combat/armes/cac/epee_batarde/epee_batarde.json
 texture=epee_batarde_lellion
 nbt.patrouille=arme_liee_lellion

--- a/assets/minecraft/optifine/cit/guildes/garde/armes/armes_liees/lellion/epee_batarde_lellion_fourreau.properties
+++ b/assets/minecraft/optifine/cit/guildes/garde/armes/armes_liees/lellion/epee_batarde_lellion_fourreau.properties
@@ -1,6 +1,6 @@
 type=item
 matchItems=diamond_sword
 hand=off
-model=~/cit/general/combat/fourreaux/fourreau_generique
+model=assets/minecraft/optifine/cit/general/combat/fourreaux/fourreau_generique.json
 texture=epee_batarde_lellion_fourreau
 nbt.patrouille=arme_liee_lellion

--- a/assets/minecraft/optifine/cit/guildes/garde/armes/armes_liees/myrrha/sabre_myrrha.properties
+++ b/assets/minecraft/optifine/cit/guildes/garde/armes/armes_liees/myrrha/sabre_myrrha.properties
@@ -1,6 +1,6 @@
 type=item
 matchItems=diamond_sword
 hand=main
-model=~/cit/general/combat/armes/cac/epee_batarde/epee_batarde
+model=assets/minecraft/optifine/cit/general/combat/armes/cac/epee_batarde/epee_batarde.json
 texture=sabre_myrrha
 nbt.patrouille=arme_liee_myrrha

--- a/assets/minecraft/optifine/cit/guildes/garde/armes/armes_liees/myrrha/sabre_myrrha_fourreau.properties
+++ b/assets/minecraft/optifine/cit/guildes/garde/armes/armes_liees/myrrha/sabre_myrrha_fourreau.properties
@@ -1,6 +1,6 @@
 type=item
 matchItems=diamond_sword
 hand=off
-model=~/cit/general/combat/fourreaux/fourreau_generique
+model=assets/minecraft/optifine/cit/general/combat/fourreaux/fourreau_generique.json
 texture=sabre_myrrha_fourreau
 nbt.patrouille=arme_liee_myrrha

--- a/assets/minecraft/optifine/cit/guildes/garde/armes/armes_liees/roland/hallebarde_roland.properties
+++ b/assets/minecraft/optifine/cit/guildes/garde/armes/armes_liees/roland/hallebarde_roland.properties
@@ -1,6 +1,6 @@
 type=item
 matchItems=diamond_axe
-model=~/cit/guildes/garde/armes/armes_liees/arme_hast
+model=assets/minecraft/optifine/cit/guildes/garde/armes/armes_liees/arme_hast.json
 texture=hallebarde_roland
 nbt.patrouille=arme_liee_roland
 weight=10

--- a/assets/minecraft/optifine/cit/guildes/garde/armes/armes_liees/rukia/epee_rukia.properties
+++ b/assets/minecraft/optifine/cit/guildes/garde/armes/armes_liees/rukia/epee_rukia.properties
@@ -1,6 +1,6 @@
 type=item
 matchItems=diamond_sword
 hand=main
-model=~/cit/source_models/messer
+model=assets/minecraft/optifine/cit/source_models/messer.json
 texture=epee_rukia
 nbt.patrouille=arme_liee_rukia

--- a/assets/minecraft/optifine/cit/guildes/garde/armes/armes_liees/rukia/epee_rukia_fourreau.properties
+++ b/assets/minecraft/optifine/cit/guildes/garde/armes/armes_liees/rukia/epee_rukia_fourreau.properties
@@ -1,6 +1,6 @@
 type=item
 matchItems=diamond_sword
 hand=off
-model=~/cit/general/combat/fourreaux/fourreau_generique
+model=assets/minecraft/optifine/cit/general/combat/fourreaux/fourreau_generique.json
 texture=epee_rukia_fourreau
 nbt.patrouille=arme_liee_rukia

--- a/assets/minecraft/optifine/cit/guildes/garde/armes/armes_liees/sfaiga/hallebarde_sfaiga.properties
+++ b/assets/minecraft/optifine/cit/guildes/garde/armes/armes_liees/sfaiga/hallebarde_sfaiga.properties
@@ -1,5 +1,5 @@
 type=item
 matchItems=diamond_axe
-model=~/cit/guildes/garde/armes/armes_liees/arme_hast
+model=assets/minecraft/optifine/cit/guildes/garde/armes/armes_liees/arme_hast.json
 texture=hallebarde_sfaiga
 nbt.patrouille=arme_liee_sfaiga

--- a/assets/minecraft/optifine/cit/guildes/garde/armes/armes_liees/soulight/marteau_a_deux_mains_soulight.properties
+++ b/assets/minecraft/optifine/cit/guildes/garde/armes/armes_liees/soulight/marteau_a_deux_mains_soulight.properties
@@ -1,5 +1,5 @@
 type=item
 matchItems=diamond_axe
-model=~/cit/guildes/garde/armes/armes_liees/arme_hast
+model=assets/minecraft/optifine/cit/guildes/garde/armes/armes_liees/arme_hast.json
 texture=marteau_a_deux_mains_soulight
 nbt.patrouille=arme_liee_soulight


### PR DESCRIPTION
Fix de beaucoup de paths érronés. Ils fonctionnaient avec optifine mais ne suivaient pas le format officiel de la doc, et ne fonctionnaient pas avec le mod CIT Resewn. Ils utilisent maintenant une racine commune et fonctionnent aussi bien sous optifine que sous sous CIT Resewn.