### PR TITLE
Fix: Epée d'entrainement

### DIFF
--- a/assets/minecraft/optifine/cit/general/combat/armes/cac/epee_entrainement/epee_entrainement.properties
+++ b/assets/minecraft/optifine/cit/general/combat/armes/cac/epee_entrainement/epee_entrainement.properties
@@ -1,7 +1,4 @@
-﻿type=item
-matchItems=minecraft:wooden_sword
+type=item
+matchItems=wooden_sword
 texture=epee_entrainement
-nbt.display.Name=iregex:.*(Epee|Ep\u00E9e|épee|ép\u00E9e).*(entrainement|entra\u00EEnement).*
-# \u00EE
-# \u00EA pour le caractère ê
-# \u00E9 pour le caratère é
+nbt.display.Name=iregex:.*(Epee|Ep\u00E9e|\u00E9pee|\u00E9p\u00E9e).*(entrainement|entra\u00EEnement).*


### PR DESCRIPTION
Certains caractères utilisés pour la regex du nom de l'item empêchais le mod CIT Resewn de la charger.

C'est désormais corrigé.