### PR TITLE
Epeefix

### DIFF
--- a/assets/minecraft/optifine/cit/general/combat/armes/cac/epee_1m/epee_1m_acier.properties
+++ b/assets/minecraft/optifine/cit/general/combat/armes/cac/epee_1m/epee_1m_acier.properties
@@ -1,4 +1,4 @@
 type=item
 matchItems=iron_sword
 texture=epee_1m_acier
-nbt.display.Name=iregex:(?=.*acier.*)(?!.*Longue.*)(?!.*(Batarde|Bâtarde).*)(.*(Epee|Ep\u00E9e|épee|ép\u00E9e).*)
+nbt.display.Name=iregex:(?=.*acier.*)(?!.*Longue.*)(?!.*(Batarde|B\u00e2tarde).*)(.*[\u00E9eE]p[\u00E9e]e.*)

--- a/assets/minecraft/optifine/cit/general/combat/armes/cac/epee_batarde/epee_batarde_acier.properties
+++ b/assets/minecraft/optifine/cit/general/combat/armes/cac/epee_batarde/epee_batarde_acier.properties
@@ -2,4 +2,4 @@ type=item
 matchItems=iron_sword
 model=epee_batarde
 texture=epee_batarde_acier
-nbt.display.Name=iregex:(.*(Epee|Ep\u00E9e|épee|ép\u00E9e).*(batarde|bâtarde).*)(.*Acier.*)
+nbt.display.Name=iregex:(.*[\u00E9eE]p[\u00E9e]e.*(batarde|b\u00e2tarde).*)(.*Acier.*)

--- a/assets/minecraft/optifine/cit/general/combat/armes/cac/epee_batarde/epee_batarde_adamantin.properties
+++ b/assets/minecraft/optifine/cit/general/combat/armes/cac/epee_batarde/epee_batarde_adamantin.properties
@@ -2,4 +2,4 @@ type=item
 matchItems=diamond_sword
 model=epee_batarde
 texture=epee_batarde_adamantin
-nbt.display.Name=iregex:.*(Epee|Ep\u00E9e|�pee|�p\u00E9e).*(batarde|b\u00e2tarde).*
+nbt.display.Name=iregex:.*[\u00E9eE]p[\u00E9e]e.*(batarde|b\u00e2tarde).*

--- a/assets/minecraft/optifine/cit/general/combat/armes/cac/epee_batarde/epee_batarde_adamantin.properties
+++ b/assets/minecraft/optifine/cit/general/combat/armes/cac/epee_batarde/epee_batarde_adamantin.properties
@@ -2,4 +2,4 @@ type=item
 matchItems=diamond_sword
 model=epee_batarde
 texture=epee_batarde_adamantin
-nbt.display.Name=iregex:.*(Epee|Ep\u00E9e|épee|ép\u00E9e).*(batarde|bâtarde).*
+nbt.display.Name=iregex:.*(Epee|Ep\u00E9e|ï¿½pee|ï¿½p\u00E9e).*(batarde|b\u00e2tarde).*

--- a/assets/minecraft/optifine/cit/general/combat/armes/cac/epee_batarde/epee_batarde_fer.properties
+++ b/assets/minecraft/optifine/cit/general/combat/armes/cac/epee_batarde/epee_batarde_fer.properties
@@ -2,4 +2,4 @@ type=item
 matchItems=iron_sword
 model=epee_batarde
 texture=epee_batarde_fer
-nbt.display.Name=iregex:(?!.*Acier.*)(.*(Epee|Ep\u00E9e|épee|ép\u00E9e).*(batarde|bâtarde).*)
+nbt.display.Name=iregex:(?!.*Acier.*)(.*[\u00E9eE]p[\u00E9e]e.*(batarde|b\u00e2tarde).*)

--- a/assets/minecraft/optifine/cit/general/combat/armes/cac/epee_entrainement/epee_entrainement.properties
+++ b/assets/minecraft/optifine/cit/general/combat/armes/cac/epee_entrainement/epee_entrainement.properties
@@ -1,4 +1,4 @@
 type=item
 matchItems=wooden_sword
 texture=epee_entrainement
-nbt.display.Name=iregex:.*(Epee|Ep\u00E9e|\u00E9pee|\u00E9p\u00E9e).*(entrainement|entra\u00EEnement).*
+nbt.display.Name=iregex:.*[\u00E9eE]p[\u00E9e]e.*(entrainement|entra\u00EEnement).*

--- a/assets/minecraft/optifine/cit/general/combat/armes/cac/epees_longues/epee_longue_acier/epee_longue_en_acier.properties
+++ b/assets/minecraft/optifine/cit/general/combat/armes/cac/epees_longues/epee_longue_acier/epee_longue_en_acier.properties
@@ -1,4 +1,4 @@
 type=item
 matchItems=iron_sword
 model=epee_longue_en_acier
-nbt.display.Name=iregex:(?=.*acier.*)(.*(Epee|Ep\u00E9e|épee|ép\u00E9e).*longue.*)
+nbt.display.Name=iregex:(?=.*acier.*)(.*[\u00E9eE]p[\u00E9e]e.*longue.*)

--- a/assets/minecraft/optifine/cit/general/combat/armes/cac/epees_longues/epee_longue_diamant/epee_longue_adamantine.properties
+++ b/assets/minecraft/optifine/cit/general/combat/armes/cac/epees_longues/epee_longue_diamant/epee_longue_adamantine.properties
@@ -1,4 +1,4 @@
 type=item
 matchItems=diamond_sword
 model=epee_longue_adamantine
-nbt.display.Name=iregex:.*(Epee|Ep\u00E9e|épee|ép\u00E9e) longue.*
+nbt.display.Name=iregex:.*[\u00E9eE]p[\u00E9e]e longue.*

--- a/assets/minecraft/optifine/cit/general/combat/armes/cac/epees_longues/epee_longue_fer/epee_longue_en_fer.properties
+++ b/assets/minecraft/optifine/cit/general/combat/armes/cac/epees_longues/epee_longue_fer/epee_longue_en_fer.properties
@@ -1,4 +1,4 @@
 type=item
 matchItems=iron_sword
 model=epee_longue_en_fer
-nbt.display.Name=iregex:(?!Acier|acier)(.*(Epee|Ep\u00E9e|épee|ép\u00E9e).*longue.*)$
+nbt.display.Name=iregex:(?!Acier|acier)(.*[\u00E9eE]p[\u00E9e]e.*longue.*)$

--- a/assets/minecraft/optifine/cit/general/combat/armes/cac/epieux/epieux.properties
+++ b/assets/minecraft/optifine/cit/general/combat/armes/cac/epieux/epieux.properties
@@ -1,4 +1,4 @@
 type=item
 matchItems=wooden_sword
 model=epieux
-nbt.display.Name=iregex:.*(Epieux|épieux).*
+nbt.display.Name=iregex:.*(Epieux|\u00E9pieux).*

--- a/assets/minecraft/optifine/cit/general/combat/armes/cac/rapiere/rapiere_acier/rapiere_acier.properties
+++ b/assets/minecraft/optifine/cit/general/combat/armes/cac/rapiere/rapiere_acier/rapiere_acier.properties
@@ -1,4 +1,4 @@
 type=item
 matchItems=iron_sword
 model=rapiere_acier
-nbt.display.Name=iregex:(?=.*acier.*)(.*(Rapiere|Rapière).*)
+nbt.display.Name=iregex:(?=.*acier.*)(.*[rR]api[\u00e8e]re.*)

--- a/assets/minecraft/optifine/cit/general/combat/armes/cac/rapiere/rapiere_diamant/rapiere_diamant.properties
+++ b/assets/minecraft/optifine/cit/general/combat/armes/cac/rapiere/rapiere_diamant/rapiere_diamant.properties
@@ -1,4 +1,4 @@
 type=item
 matchItems=diamond_sword
 model=rapiere_diamant
-nbt.display.Name=iregex:.*(Rapiere|Rapière).*
+nbt.display.Name=iregex:.*[rR]api[\u00e8e]re.*

--- a/assets/minecraft/optifine/cit/general/combat/armes/cac/rapiere/rapiere_fer/rapiere_fer.properties
+++ b/assets/minecraft/optifine/cit/general/combat/armes/cac/rapiere/rapiere_fer/rapiere_fer.properties
@@ -1,4 +1,4 @@
 type=item
 matchItems=iron_sword
 model=rapiere_fer
-nbt.display.Name=iregex:(?!Acier)(.*(Rapiere|Rapière).*)
+nbt.display.Name=iregex:(?!Acier)(.*[rR]api[\u00e8e]re.*)

--- a/assets/minecraft/optifine/cit/general/combat/fourreaux/epee_batarde_fourreau/epee_batarde_fourreau.properties
+++ b/assets/minecraft/optifine/cit/general/combat/fourreaux/epee_batarde_fourreau/epee_batarde_fourreau.properties
@@ -2,4 +2,4 @@ type=item
 matchItems=wooden_sword
 model=optifine/cit/general/combat/fourreaux/fourreau_generique
 texture=epee_batarde_fourreau
-nbt.display.Name=iregex:.*Fourreau .*(.*(epee|ep\u00E9e|épee|ép\u00E9e).*(batarde|bâtarde).*).*
+nbt.display.Name=iregex:.*Fourreau .*(.*[\u00E9e]p[\u00E9e]e.*(batarde|b\u00e2tarde).*).*

--- a/assets/minecraft/optifine/cit/general/combat/fourreaux/epee_longue_fourreau/epee_longue_fourreau.properties
+++ b/assets/minecraft/optifine/cit/general/combat/fourreaux/epee_longue_fourreau/epee_longue_fourreau.properties
@@ -2,4 +2,4 @@ type=item
 matchItems=wooden_sword
 model=optifine/cit/general/combat/fourreaux/fourreau_generique
 texture=epee_longue_fourreau
-nbt.display.Name=iregex:.*Fourreau .*(epee|ep\u00E9e|épee|ép\u00E9e) longue.*
+nbt.display.Name=iregex:.*Fourreau .*[\u00E9e]p[\u00E9e]e longue.*

--- a/assets/minecraft/optifine/cit/general/combat/fourreaux/rapiere_fourreau/rapiere_fourreau.properties
+++ b/assets/minecraft/optifine/cit/general/combat/fourreaux/rapiere_fourreau/rapiere_fourreau.properties
@@ -2,4 +2,4 @@ type=item
 matchItems=wooden_sword
 model=optifine/cit/general/combat/fourreaux/fourreau_generique
 texture=rapiere_fourreau
-nbt.display.Name=iregex:.*Fourreau .*(Rapiere|Rapière).*
+nbt.display.Name=iregex:.*Fourreau .*[rR]api[\u00e8e]re.*


### PR DESCRIPTION
Fix des accents mal formatés sur les fourreaux et les épées pour que le pack fonctionne sous sodium.

Testé sous optifine, fonctionne toujours