### PR TITLE
Correction antique.json (temporaire)

### DIFF
--- a/assets/minecraft/font/antique.json
+++ b/assets/minecraft/font/antique.json
@@ -3,7 +3,7 @@
     {
       "type": "ttf",
       "file": "antique.ttf",
-      "size": 12,
+      "size": 8,
       "oversample": 20
     }
   ]


### PR DESCRIPTION
Modification de la taille de la police de 12 à 8 dans la configuration antique.json, afin d'ajuster le rendu du texte.
Solution temporaire, dans l'attente d'une refonte de la police.

Avant :
<img width="192" height="54" alt="image_2025-09-26_230028773" src="https://github.com/user-attachments/assets/73af2214-45e7-4ff7-98c5-6160e119d071" />
<img width="733" height="472" alt="image" src="https://github.com/user-attachments/assets/12cba917-8fce-43f9-aa74-4f9f9383dd48" />

Après :
<img width="132" height="43" alt="image" src="https://github.com/user-attachments/assets/de35998a-6854-4386-af55-a66aaada5c19" />
<img width="473" height="286" alt="image" src="https://github.com/user-attachments/assets/887fa431-7384-40f1-89e3-3ad3bba55373" />